### PR TITLE
Recurse on terminate_proc.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -134,17 +134,15 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		}
 
 		foreach ( $this->running_procs as $proc ) {
-			self::terminate_proc( $proc );
+			$status = proc_get_status( $proc );
+			self::terminate_proc( $status['pid'] );
 		}
 	}
 
 	/**
 	 * Terminate a process and any of its children.
 	 */
-	private static function terminate_proc( $proc ) {
-		$status = proc_get_status( $proc );
-
-		$master_pid = $status['pid'];
+	private static function terminate_proc( $master_pid ) {
 
 		$output = `ps -o ppid,pid,command | grep $master_pid`;
 
@@ -154,9 +152,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 				$child = $matches[2];
 
 				if ( $parent == $master_pid ) {
-					if ( ! posix_kill( (int) $child, 9 ) ) {
-						throw new RuntimeException( posix_strerror( posix_get_last_error() ) );
-					}
+					self::terminate_proc( $child );
 				}
 			}
 		}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -140,7 +140,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	/**
-	 * Terminate a process and any of its children.
+	 * Terminate a process and any of its children. Takes a process id.
 	 */
 	private static function terminate_proc( $master_pid ) {
 

--- a/features/host-check.feature
+++ b/features/host-check.feature
@@ -1,6 +1,5 @@
 Feature: Check whether a WordPress install is still hosted here
 
-  @broken
   Scenario: 'hosted-valid-login' status when WordPress is functional
     Given a WP install
     And I run `wp option update home http://localhost:8181`
@@ -73,7 +72,6 @@ Feature: Check whether a WordPress install is still hosted here
       Summary: ./, missing-404
       """
 
-  @broken
   Scenario: 'hosted-broken-login' status when WordPress has a broken login
     Given a WP install
     And I run `wp option update home http://localhost:8181`
@@ -95,7 +93,6 @@ Feature: Check whether a WordPress install is still hosted here
       Summary: ./, hosted-broken-login
       """
 
-  @broken
   Scenario: 'hosted-maintenance' status when WordPress is in maintenance mode
     Given a WP install
     And I run `wp option update home http://localhost:8181`
@@ -121,7 +118,6 @@ Feature: Check whether a WordPress install is still hosted here
       Summary: ./, hosted-maintenance
       """
 
-  @broken
   Scenario: 'hosted-php-fatal' status when WordPress has a fatal error
     Given a WP install
     And I run `wp option update home http://localhost:8181`

--- a/features/host-check.feature
+++ b/features/host-check.feature
@@ -1,5 +1,6 @@
 Feature: Check whether a WordPress install is still hosted here
 
+  @require-php-5.4
   Scenario: 'hosted-valid-login' status when WordPress is functional
     Given a WP install
     And I run `wp option update home http://localhost:8181`
@@ -72,6 +73,7 @@ Feature: Check whether a WordPress install is still hosted here
       Summary: ./, missing-404
       """
 
+  @require-php-5.4
   Scenario: 'hosted-broken-login' status when WordPress has a broken login
     Given a WP install
     And I run `wp option update home http://localhost:8181`
@@ -93,6 +95,7 @@ Feature: Check whether a WordPress install is still hosted here
       Summary: ./, hosted-broken-login
       """
 
+  @require-php-5.4
   Scenario: 'hosted-maintenance' status when WordPress is in maintenance mode
     Given a WP install
     And I run `wp option update home http://localhost:8181`
@@ -118,6 +121,7 @@ Feature: Check whether a WordPress install is still hosted here
       Summary: ./, hosted-maintenance
       """
 
+  @require-php-5.4
   Scenario: 'hosted-php-fatal' status when WordPress has a fatal error
     Given a WP install
     And I run `wp option update home http://localhost:8181`


### PR DESCRIPTION
Hi, I had a look at this (via https://github.com/wp-cli/wp-cli/issues/4048) and it seems there's some grandchild process hanging around on Ubuntu (to do with `wp-cli-router.php`?), so recursing on terminate_proc() appears to fix it...